### PR TITLE
Feature psi

### DIFF
--- a/app/common/include/common/debug.h
+++ b/app/common/include/common/debug.h
@@ -10,8 +10,11 @@ level.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-All rights reserved.
+* License Agreement
+*
+* Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+* Copyright (c) 2016, Kalycito Infotech Private Ltd
+* All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -36,8 +39,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------------------------------------------------------------------------------*/
 
-#ifndef _INC_common_debug_H_
-#define _INC_common_debug_H_
+#ifndef _INC_app_common_debug_H_
+#define _INC_app_common_debug_H_
 
 /*----------------------------------------------------------------------------*/
 /* includes                                                                   */
@@ -83,6 +86,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*----------------------------------------------------------------------------*/
 /* The default debug-level is: ERROR and ALWAYS. */
 /* You can define an other debug-level in project settings. */
+
 #ifndef DEF_DEBUG_LVL
     #define DEF_DEBUG_LVL                 (DEBUG_LVL_ALWAYS | DEBUG_LVL_ERROR)
 #endif
@@ -316,5 +320,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* function prototypes                                                        */
 /*----------------------------------------------------------------------------*/
 
-#endif /* _INC_common_debug_H_ */
-
+#endif /* _INC_app_common_debug_H_ */

--- a/app/demo-sn-gpio/config/pcp/objdict.h
+++ b/app/demo-sn-gpio/config/pcp/objdict.h
@@ -1,16 +1,17 @@
 /**
 ********************************************************************************
-\file   demo-sn-gpio/config/pcp/objdict.h
+\file   config/pcp/objdict.h
 
 \brief  Object dictionary according to CiA401
 
 This file contains the object dictionary definition for the CANopen CiA401
-device profile.
+device profile and object dictionary definition for the Manufacturer Specific Profile.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 Copyright (c) 2013, SYSTEC electronic GmbH
+Copyright (c) 2016, Kalycito Infotech Private Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,227 +40,498 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <psi/obdict.h>
 
 #define OBD_DEFINE_MACRO
-    #include <oplk/obdmacro.h>
+    #include <obdcreate/obdmacro.h>
 #undef OBD_DEFINE_MACRO
 
-OBD_BEGIN ()
+OBD_BEGIN()
+    /*************************************************************************
+     * Communication Profile Area (0x1000 - 0x1FFF)
+     *************************************************************************/
+    OBD_BEGIN_PART_GENERIC()
 
-    OBD_BEGIN_PART_GENERIC ()
+        // Object 1000h: NMT_DeviceType_U32
+        OBD_BEGIN_INDEX_RAM(0x1000, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1000, 0x00, kObdTypeUInt32, kObdAccR, tObdUnsigned32, NMT_DeviceType_U32, 0x000F0191)
+        OBD_END_INDEX(0x1000)
 
-        #include "../generic/objdict_1000-13ff.h"
+        // Object 1001h: ERR_ErrorRegister_U8
+        OBD_BEGIN_INDEX_RAM(0x1001, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1001, 0x00, kObdTypeUInt8, kObdAccR, tObdUnsigned8, ERR_ErrorRegister_U8, 0x00)
+        OBD_END_INDEX(0x1001)
+
+/*
+        // Object 1003h: ERR_History_ADOM
+        OBD_RAM_INDEX_RAM_VARARRAY_NOINIT(0x1003, 10, FALSE, tObdDomain, kObdAccR, tObdDomain, ERR_History_ADOM)
+*/
+
+        // Object 1006h: NMT_CycleLen_U32 in [us]
+        OBD_BEGIN_INDEX_RAM(0x1006, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1006, 0x00, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, NMT_CycleLen_U32, 0x00000000)   // in [us]
+        OBD_END_INDEX(0x1006)
+
+        // Object 1008h: NMT_ManufactDevName_VS
+        OBD_BEGIN_INDEX_RAM(0x1008, 0x01, FALSE)
+           OBD_SUBINDEX_RAM_VSTRING(0x1008, 0x00, kObdAccR, device_name, OBD_MAX_STRING_SIZE, "openPOWERLINK device")
+        OBD_END_INDEX(0x1008)
+
+        // Object 1009h: NMT_ManufactHwVers_VS
+        OBD_BEGIN_INDEX_RAM(0x1009, 0x01, FALSE)
+           OBD_SUBINDEX_RAM_VSTRING(0x1009, 0x00, kObdAccR, hardware_version, OBD_MAX_STRING_SIZE, "1.00")
+        OBD_END_INDEX(0x1009)
+
+        // Object 100Ah: NMT_ManufactSwVers_VS
+        OBD_BEGIN_INDEX_RAM(0x100A, 0x01, FALSE)
+           OBD_SUBINDEX_RAM_VSTRING(0x100A, 0x00, kObdAccR, software_version, OBD_MAX_STRING_SIZE, PLK_PRODUCT_NAME" "PLK_PRODUCT_VERSION)
+        OBD_END_INDEX(0x100A)
+
+#if defined(CONFIG_OBD_USE_STORE_RESTORE)
+        // Object 1010h: NMT_StoreParam_REC
+        OBD_BEGIN_INDEX_RAM(0x1010, 0x05, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1010, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1010, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, AllParam_U32)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1010, 0x02, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, CommunicationParam_U32)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1010, 0x03, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, ApplicationParam_U32)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1010, 0x04, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, ManufacturerParam_U32)
+        OBD_END_INDEX(0x1010)
+
+        // Object 1011h: NMT_RestoreDefParam_REC
+        OBD_BEGIN_INDEX_RAM(0x1011, 0x05, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1011, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1011, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, AllParam_U32)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1011, 0x02, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, CommunicationParam_U32)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1011, 0x03, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, ApplicationParam_U32)
+            OBD_SUBINDEX_RAM_VAR_NOINIT(0x1011, 0x04, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, ManufacturerParam_U32)
+        OBD_END_INDEX(0x1011)
+#endif
+
+        // Object 1018h: NMT_IdentityObject_REC
+        OBD_BEGIN_INDEX_RAM(0x1018, 0x05, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1018, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_VAR(0x1018, 0x01, kObdTypeUInt32, kObdAccR, tObdUnsigned32, VendorId_U32, 0x00000000)
+            OBD_SUBINDEX_RAM_VAR(0x1018, 0x02, kObdTypeUInt32, kObdAccR, tObdUnsigned32, ProductCode_U32, 0x00000000)
+            OBD_SUBINDEX_RAM_VAR(0x1018, 0x03, kObdTypeUInt32, kObdAccR, tObdUnsigned32, RevisionNo_U32, PLK_DEFINED_OBJ1018_VERSION)
+            OBD_SUBINDEX_RAM_VAR(0x1018, 0x04, kObdTypeUInt32, kObdAccR, tObdUnsigned32, SerialNo_U32, 0x00000000)
+        OBD_END_INDEX(0x1018)
+
+        // Object 1020h: CFM_VerifyConfiguration_REC
+        OBD_BEGIN_INDEX_RAM(0x1020, 0x03, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1020, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
+            OBD_SUBINDEX_RAM_VAR(0x1020, 0x01, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, ConfDate_U32, 0x00000000)
+            OBD_SUBINDEX_RAM_VAR(0x1020, 0x02, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, ConfTime_U32, 0x00000000)
+//            OBD_SUBINDEX_RAM_VAR(0x1020, 0x03, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, ConfId_U32, 0x00000000)
+//            OBD_SUBINDEX_RAM_VAR(0x1020, 0x04, kObdTypeBool, kObdAccR, tObdBoolean, VerifyConfInvalid_BOOL, 0x01)
+        OBD_END_INDEX(0x1020)
+
+        // Object 1030h: NMT_InterfaceGroup_Xh_REC
+        OBD_BEGIN_INDEX_RAM(0x1030, 0x0A, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1030, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x09)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1030, 0x01, kObdTypeUInt16, kObdAccR, tObdUnsigned16, InterfaceIndex_U16, 0x01, 0x00, 0x0A)
+            OBD_SUBINDEX_RAM_VSTRING(0x1030, 0x02, kObdAccR, InterfaceDescription_VSTR, 0x20, "Interface 1")
+            OBD_SUBINDEX_RAM_VAR(0x1030, 0x03, kObdTypeUInt8, kObdAccR, tObdUnsigned8, InterfaceType_U8, 0x06)
+            OBD_SUBINDEX_RAM_VAR(0x1030, 0x04, kObdTypeUInt16, kObdAccR, tObdUnsigned16, InterfaceMtu_U16, 1518)
+            OBD_SUBINDEX_RAM_OSTRING(0x1030, 0x05, kObdAccR, InterfacePhysAddress_OSTR, 0x06)
+            OBD_SUBINDEX_RAM_VSTRING(0x1030, 0x06, kObdAccR, InterfaceName_VSTR, 0x20, "Interface 1")
+            OBD_SUBINDEX_RAM_VAR_RG(0x1030, 0x07, kObdTypeUInt8, kObdAccR, tObdUnsigned8, InterfaceOperStatus_U8, 0x01, 0x00, 0x01)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1030, 0x08, kObdTypeUInt8, kObdAccGRW, tObdUnsigned8, InterfaceAdminState_U8, 0x01, 0x00, 0x01)
+            OBD_SUBINDEX_RAM_VAR(0x1030, 0x09, kObdTypeBool, kObdAccRW, tObdBoolean, Valid_BOOL, 0x01)
+        OBD_END_INDEX(0x1030)
+
+#if (defined(CONFIG_DLL_PRES_CHAINING_CN) && (NMT_MAX_NODE_ID > 0))
+        // Object 1050h: NMT_RelativeLatencyDiff_AU32
+        OBD_RAM_INDEX_RAM_ARRAY(0x1050, NMT_MAX_NODE_ID, FALSE, kObdTypeUInt32, kObdAccR, tObdUnsigned32, NMT_RelativeLatencyDiff_AU32, 0)
+#endif
+
+        // Object 1300h: SDO_SequLayerTimeout_U32 in [ms]
+        OBD_BEGIN_INDEX_RAM(0x1300, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1300, 0x00, kObdTypeUInt32, kObdAccSGRW, tObdUnsigned32, SDO_SequLayerTimeout_U32, 15000, 100, 0xFFFFFFFF)
+        OBD_END_INDEX(0x1300)
 
         // Object 1400h: PDO_RxCommParam_00h_REC
-        OBD_BEGIN_INDEX_RAM(0x1400, 0x03, pdou_cbObdAccess)
+        OBD_BEGIN_INDEX_RAM(0x1400, 0x03, TRUE)
             OBD_SUBINDEX_RAM_VAR(0x1400, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
-            OBD_SUBINDEX_RAM_VAR(0x1400, 0x01, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NodeID_U8, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1400, 0x02, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, MappingVersion_U8, 0x00)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1400, 0x01, kObdTypeUInt8, kObdAccSGRW, tObdUnsigned8, NodeID_U8, 0, 0, 254)
+            OBD_SUBINDEX_RAM_VAR(0x1400, 0x02, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, MappingVersion_U8, 0x00)
         OBD_END_INDEX(0x1400)
 
         // Object 1401h: PDO_RxCommParam_01h_REC
-        OBD_BEGIN_INDEX_RAM(0x1401, 0x03, pdou_cbObdAccess)
+        OBD_BEGIN_INDEX_RAM(0x1401, 0x03, TRUE)
             OBD_SUBINDEX_RAM_VAR(0x1401, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
-            OBD_SUBINDEX_RAM_VAR(0x1401, 0x01, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NodeID_U8, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1401, 0x02, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, MappingVersion_U8, 0x00)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1401, 0x01, kObdTypeUInt8, kObdAccSGRW, tObdUnsigned8, NodeID_U8, 0, 0, 254)
+            OBD_SUBINDEX_RAM_VAR(0x1401, 0x02, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, MappingVersion_U8, 0x00)
         OBD_END_INDEX(0x1401)
 
         // Object 1402h: PDO_RxCommParam_02h_REC
-        OBD_BEGIN_INDEX_RAM(0x1402, 0x03, pdou_cbObdAccess)
+        OBD_BEGIN_INDEX_RAM(0x1402, 0x03, TRUE)
             OBD_SUBINDEX_RAM_VAR(0x1402, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
-            OBD_SUBINDEX_RAM_VAR(0x1402, 0x01, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NodeID_U8, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1402, 0x02, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, MappingVersion_U8, 0x00)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1402, 0x01, kObdTypeUInt8, kObdAccSGRW, tObdUnsigned8, NodeID_U8, 0, 0, 254)
+            OBD_SUBINDEX_RAM_VAR(0x1402, 0x02, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, MappingVersion_U8, 0x00)
         OBD_END_INDEX(0x1402)
 
         // Object 1600h: PDO_RxMappParam_00h_AU64
-        OBD_BEGIN_INDEX_RAM(0x1600, 0x1A, pdou_cbObdAccess)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x00, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NumberOfEntries, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x01, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x02, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x03, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x04, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x05, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x06, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x07, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x08, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x09, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0A, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0B, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0C, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0D, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0E, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0F, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x10, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x11, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x12, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x13, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x14, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x15, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x16, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x17, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x18, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1600, 0x19, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
+        OBD_BEGIN_INDEX_RAM(0x1600, 0x1A, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x00, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, NumberOfEntries, 0x00)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x01, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x02, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x03, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x04, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x05, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x06, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x07, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x08, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x09, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0A, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0B, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0C, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0D, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0E, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x0F, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x10, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x11, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x12, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x13, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x14, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x15, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x16, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x17, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x18, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1600, 0x19, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
         OBD_END_INDEX(0x1600)
 
         // Object 1601h: PDO_RxMappParam_01h_AU64
-        OBD_BEGIN_INDEX_RAM(0x1601, 0x1A, pdou_cbObdAccess)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x00, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NumberOfEntries, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x01, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x02, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x03, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x04, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x05, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x06, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x07, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x08, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x09, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0A, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0B, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0C, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0D, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0E, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0F, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x10, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x11, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x12, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x13, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x14, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x15, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x16, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x17, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x18, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1601, 0x19, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
+        OBD_BEGIN_INDEX_RAM(0x1601, 0x1A, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x00, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, NumberOfEntries, 0x00)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x01, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x02, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x03, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x04, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x05, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x06, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x07, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x08, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x09, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0A, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0B, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0C, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0D, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0E, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x0F, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x10, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x11, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x12, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x13, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x14, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x15, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x16, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x17, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x18, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1601, 0x19, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
         OBD_END_INDEX(0x1601)
 
         // Object 1602h: PDO_RxMappParam_02h_AU64
-        OBD_BEGIN_INDEX_RAM(0x1602, 0x1A, pdou_cbObdAccess)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x00, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NumberOfEntries, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x01, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x02, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x03, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x04, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x05, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x06, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x07, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x08, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x09, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0A, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0B, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0C, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0D, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0E, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0F, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x10, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x11, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x12, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x13, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x14, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x15, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x16, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x17, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x18, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1602, 0x19, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
+        OBD_BEGIN_INDEX_RAM(0x1602, 0x1A, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x00, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, NumberOfEntries, 0x00)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x01, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x02, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x03, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x04, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x05, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x06, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x07, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x08, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x09, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0A, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0B, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0C, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0D, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0E, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x0F, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x10, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x11, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x12, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x13, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x14, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x15, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x16, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x17, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x18, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1602, 0x19, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
         OBD_END_INDEX(0x1602)
 
         // Object 1800h: PDO_TxCommParam_00h_REC
-        OBD_BEGIN_INDEX_RAM(0x1800, 0x03, pdou_cbObdAccess)
+        OBD_BEGIN_INDEX_RAM(0x1800, 0x03, TRUE)
             OBD_SUBINDEX_RAM_VAR(0x1800, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
-            OBD_SUBINDEX_RAM_VAR(0x1800, 0x01, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NodeID_U8, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x1800, 0x02, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, MappingVersion_U8, 0x00)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1800, 0x01, kObdTypeUInt8, kObdAccSGRW, tObdUnsigned8, NodeID_U8, 0, 0, 254)
+            OBD_SUBINDEX_RAM_VAR(0x1800, 0x02, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, MappingVersion_U8, 0x00)
         OBD_END_INDEX(0x1800)
 
         // Object 1A00h: PDO_TxMappParam_00h_AU64
-        OBD_BEGIN_INDEX_RAM(0x1A00, 0x1A, pdou_cbObdAccess)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x00, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NumberOfEntries, 0x0)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x01, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x02, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x03, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x04, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x05, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x06, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x07, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x08, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x09, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0A, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0B, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0C, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0D, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0E, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0F, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x10, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x11, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x12, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x13, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x14, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x15, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x16, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x17, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x18, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
-            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x19, kObdTypeUInt64, kObdAccRW, tObdUnsigned64, ObjectMapping, 0x00LL)
+        OBD_BEGIN_INDEX_RAM(0x1A00, 0x1A, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x00, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, NumberOfEntries, 0x00)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x01, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x02, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x03, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x04, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x05, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x06, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x07, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x08, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x09, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0A, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0B, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0C, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0D, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0E, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x0F, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x10, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x11, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x12, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x13, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x14, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x15, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x16, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x17, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x18, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
+            OBD_SUBINDEX_RAM_VAR(0x1A00, 0x19, kObdTypeUInt64, kObdAccSRW, tObdUnsigned64, ObjectMapping, 0x0000000000000000LL)
         OBD_END_INDEX(0x1A00)
 
-        #include "../generic/objdict_1b00-1fff.h"
+        // Object 1C0Bh: DLL_CNLossSoC_REC
+        OBD_BEGIN_INDEX_RAM(0x1C0B, 0x04, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1C0B, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 3)
+            OBD_SUBINDEX_RAM_USERDEF_NOINIT(0x1C0B, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, CumulativeCnt_U32)
+            OBD_SUBINDEX_RAM_USERDEF(0x1C0B, 0x02, kObdTypeUInt32, kObdAccR, tObdUnsigned32, ThresholdCnt_U32, 0)
+            OBD_SUBINDEX_RAM_USERDEF(0x1C0B, 0x03, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, Threshold_U32, 15)
+        OBD_END_INDEX(0x1C0B)
 
-    OBD_END_PART ()
+        // Object 1C0Dh: DLL_CNLossPReq_REC
+        OBD_BEGIN_INDEX_RAM(0x1C0D, 0x04, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1C0D, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 3)
+            OBD_SUBINDEX_RAM_USERDEF_NOINIT(0x1C0D, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, CumulativeCnt_U32)
+            OBD_SUBINDEX_RAM_USERDEF(0x1C0D, 0x02, kObdTypeUInt32, kObdAccR, tObdUnsigned32, ThresholdCnt_U32, 0)
+            OBD_SUBINDEX_RAM_USERDEF(0x1C0D, 0x03, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, Threshold_U32, 15)
+        OBD_END_INDEX(0x1C0D)
 
-    OBD_BEGIN_PART_MANUFACTURER ()
+        // Object 1C0Fh: DLL_CNCRCError_REC
+        OBD_BEGIN_INDEX_RAM(0x1C0F, 0x04, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1C0F, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 3)
+            OBD_SUBINDEX_RAM_USERDEF_NOINIT(0x1C0F, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, CumulativeCnt_U32)
+            OBD_SUBINDEX_RAM_USERDEF(0x1C0F, 0x02, kObdTypeUInt32, kObdAccR, tObdUnsigned32, ThresholdCnt_U32, 0)
+            OBD_SUBINDEX_RAM_USERDEF(0x1C0F, 0x03, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, Threshold_U32, 15)
+        OBD_END_INDEX(0x1C0F)
+
+        // Object 1C14h: DLL_LossOfSocTolerance_U32 in [ns]
+        OBD_BEGIN_INDEX_RAM(0x1C14, 0x01, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1C14, 0x00, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, LossOfSocTolerance, 100000)
+        OBD_END_INDEX(0x1C14)
+
+#if defined(CONFIG_INCLUDE_IP)
+        // Object 1E40h: NWL_IpAddrTable_0h_REC
+        OBD_BEGIN_INDEX_RAM(0x1E40, 0x06, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1E40, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x05)
+            OBD_SUBINDEX_RAM_VAR(0x1E40, 0x01, kObdTypeUInt16, kObdAccR, tObdUnsigned16, IfIndex_U16, 0x01)
+            OBD_SUBINDEX_RAM_VAR(0x1E40, 0x02, kObdTypeUInt32, kObdAccR, tObdUnsigned32, Addr_IPAD, 0xC0A86401)
+            OBD_SUBINDEX_RAM_VAR(0x1E40, 0x03, kObdTypeUInt32, kObdAccR, tObdUnsigned32, NetMask_IPAD, 0xFFFFFF00)
+            OBD_SUBINDEX_RAM_VAR(0x1E40, 0x04, kObdTypeUInt16, kObdAccR, tObdUnsigned16, ReasmMaxSize_U16, 50000)
+            OBD_SUBINDEX_RAM_VAR(0x1E40, 0x05, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, DefaultGateway_IPAD, 0xC0A864FE)
+        OBD_END_INDEX(0x1E40)
+
+        // Object 1E4Ah: NWL_IpGroup_REC
+        OBD_BEGIN_INDEX_RAM(0x1E4A, 0x06, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1E4A, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x03)
+            OBD_SUBINDEX_RAM_VAR(0x1E4A, 0x01, kObdTypeBool, kObdAccSRW, tObdBoolean, Forwarding_BOOL, 0x00)
+            OBD_SUBINDEX_RAM_VAR(0x1E4A, 0x02, kObdTypeUInt16, kObdAccSRW, tObdUnsigned16, DefaultTTL_U16, 64)
+            OBD_SUBINDEX_RAM_VAR(0x1E4A, 0x03, kObdTypeUInt32, kObdAccR, tObdUnsigned32, ForwardDatagrams_U32, 0x00000000)
+        OBD_END_INDEX(0x1E4A)
+#endif
+
+#if NMT_MAX_NODE_ID > 0
+        // Object 1F81h: NMT_NodeAssignment_AU32
+        OBD_RAM_INDEX_RAM_ARRAY_ALT(0x1F81, NMT_MAX_NODE_ID, FALSE, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, NMT_NodeAssignment_AU32, 0)
+#endif
+
+        // Object 1F82h: NMT_FeatureFlags_U32
+        OBD_BEGIN_INDEX_RAM(0x1F82, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F82, 0x00, kObdTypeUInt32, kObdAccR, tObdUnsigned32, NMT_FeatureFlags_U32, PLK_DEF_FEATURE_FLAGS)
+        OBD_END_INDEX(0x1F82)
+
+        // Object 1F83h: NMT_EPLVersion_U8
+        OBD_BEGIN_INDEX_RAM(0x1F83, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F83, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NMT_EPLVersion_U8, 0x20)
+        OBD_END_INDEX(0x1F83)
+
+        // Object 1F8Ch: NMT_CurrNMTState_U8
+        OBD_BEGIN_INDEX_RAM(0x1F8C, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F8C, 0x00, kObdTypeUInt8, (kObdAccR | kObdAccPdo), tObdUnsigned8, NMT_CurrNMTState_U8, 0x1C)
+        OBD_END_INDEX(0x1F8C)
+
+#if NMT_MAX_NODE_ID > 0
+        // Object 1F8Dh: NMT_PResPayloadLimitList_AU16
+        OBD_RAM_INDEX_RAM_ARRAY_ALT(0x1F8D, NMT_MAX_NODE_ID, FALSE, kObdTypeUInt16, kObdAccSRW, tObdUnsigned16, NMT_PResPayloadLimitList_AU16, 36)
+#endif
+
+        // Object 1F93h: NMT_EPLNodeID_REC
+        OBD_BEGIN_INDEX_RAM(0x1F93, 0x03, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F93, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
+            OBD_SUBINDEX_RAM_VAR(0x1F93, 0x01, kObdTypeUInt8, kObdAccR, tObdUnsigned8, NodeID_U8, 0)
+            OBD_SUBINDEX_RAM_VAR(0x1F93, 0x02, kObdTypeBool, kObdAccR, tObdBoolean, NodeIDByHW_BOOL, 0x00)
+        OBD_END_INDEX(0x1F93)
+
+        // Object 1F98h: NMT_CycleTiming_REC
+#if !defined(CONFIG_DLL_PRES_CHAINING_CN)
+        OBD_BEGIN_INDEX_RAM(0x1F98, 0x0A, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x09)
+#else
+        OBD_BEGIN_INDEX_RAM(0x1F98, 0x0F, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x0E)
+#endif
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x01, kObdTypeUInt16, kObdAccR, tObdUnsigned16, IsochrTxMaxPayload_U16, 0)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x02, kObdTypeUInt16, kObdAccR, tObdUnsigned16, IsochrRxMaxPayload_U16, 0)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x03, kObdTypeUInt32, kObdAccR, tObdUnsigned32, PResMaxLatency_U32, 0)     // in [ns]
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x04, kObdTypeUInt16, kObdAccSRW, tObdUnsigned16, PReqActPayloadLimit_U16, 36)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x05, kObdTypeUInt16, kObdAccSRW, tObdUnsigned16, PResActPayloadLimit_U16, 36)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x06, kObdTypeUInt32, kObdAccR, tObdUnsigned32, ASndMaxLatency_U32, 0)     // in [ns]
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x07, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, MultiplCycleCnt_U8, 0x00)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1F98, 0x08, kObdTypeUInt16, kObdAccSGRW, tObdUnsigned16, AsyncMTU_U16, C_DLL_MIN_ASYNC_MTU, C_DLL_MIN_ASYNC_MTU, C_DLL_MAX_ASYNC_MTU)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1F98, 0x09, kObdTypeUInt16, kObdAccSRW, tObdUnsigned16, Prescaler_U16, 2, 0, 1000)
+#if defined(CONFIG_DLL_PRES_CHAINING_CN)
+            OBD_SUBINDEX_RAM_VAR_RG(0x1F98, 0x0A, kObdTypeUInt8, kObdAccGR, tObdUnsigned8, PResMode_U8, 0x00, 0x00, 0x01)
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x0B, kObdTypeUInt32, kObdAccR, tObdUnsigned32, PResTimeFirst_U32, 0)      // in [ns]
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x0C, kObdTypeUInt32, kObdAccR, tObdUnsigned32, PResTimeSecond_U32, 0)     // in [ns]
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x0D, kObdTypeUInt32, kObdAccR, tObdUnsigned32, SyncMNDelayFirst_U32, 0)   // in [ns]
+            OBD_SUBINDEX_RAM_VAR(0x1F98, 0x0E, kObdTypeUInt32, kObdAccR, tObdUnsigned32, SyncMNDelaySecond_U32, 0)  // in [ns]
+#endif
+        OBD_END_INDEX(0x1F98)
+
+        // Object 1F99h: NMT_CNBasicEthernetTimeout_U32 in [us]
+        OBD_BEGIN_INDEX_RAM(0x1F99, 0x01, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x1F99, 0x00, kObdTypeUInt32, kObdAccSRW, tObdUnsigned32, NMT_CNBasicEthernetTimeout_U32, 5000000)  // in [us]
+        OBD_END_INDEX(0x1F99)
+
+#if defined(CONFIG_INCLUDE_IP)
+        // Object 1F9Ah: NMT_HostName_VSTR
+        OBD_BEGIN_INDEX_RAM(0x1F9A, 0x01, FALSE)
+           OBD_SUBINDEX_RAM_VSTRING(0x1F9A, 0x00, kObdAccSRW, NMT_HostName_VSTR, 34, "")
+        OBD_END_INDEX(0x1F9A)
+#endif
+
+#if NMT_MAX_NODE_ID > 0
+        // Object 1F9Bh: NMT_MultiplCycleAssign_AU8
+        OBD_RAM_INDEX_RAM_ARRAY_ALT(0x1F9B, NMT_MAX_NODE_ID, FALSE, kObdTypeUInt8, kObdAccSRW, tObdUnsigned8, NMT_MultiplCycleAssign_AU8, 0)
+#endif
+
+        // Object 1F9Eh: NMT_ResetCmd_U8
+        OBD_BEGIN_INDEX_RAM(0x1F9E, 0x01, TRUE)
+            OBD_SUBINDEX_RAM_VAR(0x1F9E, 0x00, kObdTypeUInt8, kObdAccRW, tObdUnsigned8, NMT_ResetCmd_U8, 0xFF)
+        OBD_END_INDEX(0x1F9E)
+
+    OBD_END_PART()
+
+    /*************************************************************************
+     * Manufacturer Specific Profile Area (0x2000 - 0x5FFF)
+     *************************************************************************/
+    OBD_BEGIN_PART_MANUFACTURER()
 
         // add manufacturer part objects (2000h .. 5fffh) here
 
-#if(((PSI_MODULE_INTEGRATION) & (PSI_MODULE_CC)) != 0)
-        OBD_BEGIN_INDEX_RAM(0x2000, 0x05, cc_obdAccessCb)
-            OBD_SUBINDEX_RAM_VAR(0x2000, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
-            OBD_SUBINDEX_RAM_VAR(0x2000, 0x01, kObdTypeUInt16, kObdAccRW, tObdUnsigned16, UserParameter_01, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x2000, 0x02, kObdTypeUInt16, kObdAccRW, tObdUnsigned16, UserParameter_02, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x2000, 0x03, kObdTypeUInt16, kObdAccRW, tObdUnsigned16, UserParameter_03, 0x00)
-            OBD_SUBINDEX_RAM_VAR(0x2000, 0x04, kObdTypeUInt16, kObdAccRW, tObdUnsigned16, UserParameter_04, 0x00)
-        OBD_END_INDEX(0x2000)
-#endif
-
 #if(((PSI_MODULE_INTEGRATION) & (PSI_MODULE_SSDO)) != 0)
         // SSDO-Stub
-        OBD_BEGIN_INDEX_RAM(0x2110, 0x02, NULL)
+        OBD_BEGIN_INDEX_RAM(0x2110, 0x02, FALSE)
             OBD_SUBINDEX_RAM_VAR(0x2110, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
             OBD_SUBINDEX_RAM_VAR(0x2110, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, SSDOStubAddress_U32, 0x00)
         OBD_END_INDEX(0x2110)
-
-        // SSDO-StubData
-        OBD_BEGIN_INDEX_RAM(0x2130, 0x02, rssdo_obdAccessCb)
-            OBD_SUBINDEX_RAM_VAR(0x2130, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
-            OBD_SUBINDEX_RAM_OSTRING(0x2130, 0x01, kObdAccRW, SSDOStubData_DOM, SSDO_STUB_DATA_DOM_SIZE)
-        OBD_END_INDEX(0x2130)
 #endif
 
 #if(((PSI_MODULE_INTEGRATION) & (PSI_MODULE_LOGBOOK)) != 0)
         // LOG-Stub
-        OBD_BEGIN_INDEX_RAM(0x2403, 0x02, NULL)
+        OBD_BEGIN_INDEX_RAM(0x2403, 0x02, FALSE)
             OBD_SUBINDEX_RAM_VAR(0x2403, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
             OBD_SUBINDEX_RAM_VAR(0x2403, 0x01, kObdTypeUInt32, kObdAccRW, tObdUnsigned32, LOGStubAddress_U32, 0x00)
         OBD_END_INDEX(0x2403)
 #endif
 
         // Input SPDO channel
-        OBD_BEGIN_INDEX_RAM(0x4000, 0x02, NULL)
+        OBD_BEGIN_INDEX_RAM(0x4000, 0x02, FALSE)
             OBD_SUBINDEX_RAM_VAR(0x4000, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
             OBD_SUBINDEX_RAM_DOMAIN(0x4000, 0x01, kObdAccVPR, SafeIN0)
         OBD_END_INDEX(0x4000)
 
         // Output SPDO channel
-        OBD_BEGIN_INDEX_RAM(0x4001, 0x02, NULL)
+        OBD_BEGIN_INDEX_RAM(0x4001, 0x02, FALSE)
             OBD_SUBINDEX_RAM_VAR(0x4001, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
             OBD_SUBINDEX_RAM_DOMAIN(0x4001, 0x01, kObdAccVPRW, SafeOUT0)
         OBD_END_INDEX(0x4001)
 
-    OBD_END_PART ()
+        OBD_END_PART()
+    /*************************************************************************
+     * Standardised Device Profile Area (0x6000 - 0x9FFF)
+     *************************************************************************/
+    OBD_BEGIN_PART_DEVICE()
 
-    OBD_BEGIN_PART_DEVICE ()
+        // DigitalInput_00h_AU8
+        OBD_BEGIN_INDEX_RAM(0x6000, 0x05, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6000, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_USERDEF(0x6000, 0x01, kObdTypeUInt8, kObdAccVPR, tObdUnsigned8, DigitalInput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6000, 0x02, kObdTypeUInt8, kObdAccVPR, tObdUnsigned8, DigitalInput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6000, 0x03, kObdTypeUInt8, kObdAccVPR, tObdUnsigned8, DigitalInput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6000, 0x04, kObdTypeUInt8, kObdAccVPR, tObdUnsigned8, DigitalInput, 0x00)
+        OBD_END_INDEX(0x6000)
 
+        // DigitalOutput_00h_AU8
+        OBD_BEGIN_INDEX_RAM(0x6200, 0x05, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6200, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_USERDEF(0x6200, 0x01, kObdTypeUInt8, kObdAccVPRW, tObdUnsigned8, DigitalOutput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6200, 0x02, kObdTypeUInt8, kObdAccVPRW, tObdUnsigned8, DigitalOutput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6200, 0x03, kObdTypeUInt8, kObdAccVPRW, tObdUnsigned8, DigitalOutput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6200, 0x04, kObdTypeUInt8, kObdAccVPRW, tObdUnsigned8, DigitalOutput, 0x00)
+        OBD_END_INDEX(0x6200)
 
+        // AnalogueInput_00h_AI8
+        OBD_BEGIN_INDEX_RAM(0x6400, 0x05, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6400, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_USERDEF(0x6400, 0x01, kObdTypeInt8, kObdAccVPR, tObdInteger8, AnalogueInput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6400, 0x02, kObdTypeInt8, kObdAccVPR, tObdInteger8, AnalogueInput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6400, 0x03, kObdTypeInt8, kObdAccVPR, tObdInteger8, AnalogueInput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6400, 0x04, kObdTypeInt8, kObdAccVPR, tObdInteger8, AnalogueInput, 0x00)
+        OBD_END_INDEX(0x6400)
 
-    OBD_END_PART ()
+        // AnalogueInput_00h_AI16
+        OBD_BEGIN_INDEX_RAM(0x6401, 0x03, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6401, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
+            OBD_SUBINDEX_RAM_USERDEF(0x6401, 0x01, kObdTypeInt16, kObdAccVPR, tObdInteger16, AnalogueInput, 0x0000)
+            OBD_SUBINDEX_RAM_USERDEF(0x6401, 0x02, kObdTypeInt16, kObdAccVPR, tObdInteger16, AnalogueInput, 0x0000)
+        OBD_END_INDEX(0x6401)
 
-OBD_END ()
+        // AnalogueInput_00h_AI32
+        OBD_BEGIN_INDEX_RAM(0x6402, 0x02, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6402, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
+            OBD_SUBINDEX_RAM_USERDEF(0x6402, 0x01, kObdTypeInt32, kObdAccVPR, tObdInteger32, AnalogueInput, 0x00000000)
+        OBD_END_INDEX(0x6402)
 
+        // AnalogueOutput_00h_AI8
+        OBD_BEGIN_INDEX_RAM(0x6410, 0x05, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6410, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x04)
+            OBD_SUBINDEX_RAM_USERDEF(0x6410, 0x01, kObdTypeInt8, kObdAccVPRW, tObdInteger8, AnalogueOutput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6410, 0x02, kObdTypeInt8, kObdAccVPRW, tObdInteger8, AnalogueOutput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6410, 0x03, kObdTypeInt8, kObdAccVPRW, tObdInteger8, AnalogueOutput, 0x00)
+            OBD_SUBINDEX_RAM_USERDEF(0x6410, 0x04, kObdTypeInt8, kObdAccVPRW, tObdInteger8, AnalogueOutput, 0x00)
+        OBD_END_INDEX(0x6410)
+
+        // AnalogueOutput_00h_AI16
+        OBD_BEGIN_INDEX_RAM(0x6411, 0x03, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6411, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x02)
+            OBD_SUBINDEX_RAM_USERDEF(0x6411, 0x01, kObdTypeInt16, kObdAccVPRW, tObdInteger16, AnalogueOutput, 0x0000)
+            OBD_SUBINDEX_RAM_USERDEF(0x6411, 0x02, kObdTypeInt16, kObdAccVPRW, tObdInteger16, AnalogueOutput, 0x0000)
+        OBD_END_INDEX(0x6411)
+
+        // AnalogueOutput_00h_AI32
+        OBD_BEGIN_INDEX_RAM(0x6412, 0x02, FALSE)
+            OBD_SUBINDEX_RAM_VAR(0x6412, 0x00, kObdTypeUInt8, kObdAccConst, tObdUnsigned8, NumberOfEntries, 0x01)
+            OBD_SUBINDEX_RAM_USERDEF(0x6412, 0x01, kObdTypeInt32, kObdAccVPRW, tObdInteger32, AnalogueOutput, 0x00000000)
+        OBD_END_INDEX(0x6412)
+
+    OBD_END_PART()
+
+OBD_END()
 
 #define OBD_UNDEFINE_MACRO
-    #include <oplk/obdmacro.h>
+    #include <obdcreate/obdmacro.h>
 #undef OBD_UNDEFINE_MACRO
-

--- a/blackchannel/POWERLINK/fpga/boards/altera/terasic-de2-115/cn-pcp-spi/cnPcpSpi.qsys
+++ b/blackchannel/POWERLINK/fpga/boards/altera/terasic-de2-115/cn-pcp-spi/cnPcpSpi.qsys
@@ -276,8 +276,8 @@
    dir="end" />
  <interface
    name="openmac_0_mactimerout"
-   internal="openmac_0.macTimerOut"
-   type="conduit"
+   internal="openmac_0.timerPulse"
+   type="interrupt"
    dir="end" />
  <interface
    name="pcp_0_epcs_flash"
@@ -508,7 +508,7 @@
   <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone IV E" />
   <parameter name="AUTO_DEVICE" value="EP4CE115F29C7" />
  </module>
- <module kind="openmac" version="1.0.0" enabled="1" name="openmac_0">
+ <module kind="openmac" version="1.0.2" enabled="1" name="openmac_0">
   <parameter name="sys_mainClk" value="50000000" />
   <parameter name="sys_mainClkx2" value="100000000" />
   <parameter name="sys_dmaAddrWidth" value="21" />
@@ -521,7 +521,7 @@
   <parameter name="gui_rxBufLoc" value="2" />
   <parameter name="gui_rxBufSize" value="1" />
   <parameter name="gui_rxBurstSize" value="4" />
-  <parameter name="gui_tmrCount" value="2" />
+  <parameter name="gui_tmrPulse" value="true" />
   <parameter name="gui_tmrPulseEn" value="true" />
   <parameter name="gui_tmrPulseWdt" value="10" />
   <parameter name="gui_actEn" value="false" />
@@ -618,7 +618,7 @@
    start="pcp_0.slow_bridge"
    end="sysid.control_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x2d40" />
+  <parameter name="baseAddress" value="0x2d50" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -627,7 +627,7 @@
    start="pcp_0.slow_bridge"
    end="node_switch_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x2d30" />
+  <parameter name="baseAddress" value="0x2d40" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection kind="reset" version="13.0" start="clk50.clk_reset" end="sysid.reset" />

--- a/blackchannel/POWERLINK/fpga/boards/altera/terasic-de2-115/cn-pcp-spi/toplevel.vhd
+++ b/blackchannel/POWERLINK/fpga/boards/altera/terasic-de2-115/cn-pcp-spi/toplevel.vhd
@@ -134,7 +134,7 @@ architecture rtl of toplevel is
             -- BENCHMARK PCP
             pcp_0_benchmark_pio_export              : out   std_logic_vector(7 downto 0);
             -- SYNC IRQ
-            openmac_0_mactimerout_export            : out   std_logic_vector(1 downto 0)
+            openmac_0_mactimerout_irq               : out   std_logic
         );
     end component cnPcpSpi;
 
@@ -156,7 +156,7 @@ architecture rtl of toplevel is
     signal pllLocked        : std_logic;
     signal sramAddr         : std_logic_vector(SRAM_ADDR'high downto 0);
     signal plk_status_error : std_logic_vector(1 downto 0);
-    signal timer_out        : std_logic_vector(1 downto 0);
+    signal timer_out        : std_logic;
 begin
     SRAM_ADDR   <= sramAddr(SRAM_ADDR'range);
 
@@ -165,7 +165,7 @@ begin
 
     LEDG        <= "000000" & plk_status_error;
 
-    SYNC_IRQ    <= timer_out(1);
+    SYNC_IRQ    <= timer_out;
 
     inst: cnPcpSpi
         port map (
@@ -208,7 +208,7 @@ begin
             -- BENCHMARK PCP
             pcp_0_benchmark_pio_export                      => BENCHMARK_PCP,
             -- SYNC IRQ
-            openmac_0_mactimerout_export                    => timer_out
+            openmac_0_mactimerout_irq                    => timer_out
         );
 
     -- Pll Instance

--- a/blackchannel/POWERLINK/libs/psicommon/amile.c
+++ b/blackchannel/POWERLINK/libs/psicommon/amile.c
@@ -16,6 +16,7 @@ always copies bytewise)
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2016, Kalycito Infotech Private Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -131,7 +132,7 @@ Reads a 16 bit value from a buffer in big endian
 \retval Value       The data in platform endian
 */
 /*----------------------------------------------------------------------------*/
-UINT16 ami_getUint16Be(void* pAddr_p)
+UINT16 ami_getUint16Be(const void* pAddr_p)
 {
     UINT16 val;
 
@@ -153,7 +154,7 @@ Reads a 16 bit value from a buffer in little endian
 \retval Value       The data in platform endian
 */
 /*----------------------------------------------------------------------------*/
-UINT16 ami_getUint16Le(void* pAddr_p)
+UINT16 ami_getUint16Le(const void* pAddr_p)
 {
     UINT16 val;
 
@@ -211,7 +212,7 @@ Reads a 32 bit value from a buffer in big endian
 \retval Value       The data in platform endian
 */
 /*----------------------------------------------------------------------------*/
-UINT32 ami_getUint32Be(void* pAddr_p)
+UINT32 ami_getUint32Be(const void* pAddr_p)
 {
     UINT32 val;
 
@@ -235,7 +236,7 @@ Reads a 32 bit value from a buffer in little endian
 \retval Value       The data in platform endian
 */
 /*----------------------------------------------------------------------------*/
-UINT32 ami_getUint32Le(void* pAddr_p)
+UINT32 ami_getUint32Le(const void* pAddr_p)
 {
     UINT32 val;
 
@@ -303,7 +304,7 @@ Reads a 64 bit value from a buffer in big endian
 \retval Value       The data in platform endian
 */
 /*----------------------------------------------------------------------------*/
-UINT64 ami_getUint64Be(void* pAddr_p)
+UINT64 ami_getUint64Be(const void* pAddr_p)
 {
     UINT64 val;
 
@@ -331,7 +332,7 @@ Reads a 64 bit value from a buffer in little endian
 \retval Value       The data in platform endian
 */
 /*----------------------------------------------------------------------------*/
-UINT64 ami_getUint64Le(void* pAddr_p)
+UINT64 ami_getUint64Le(const void* pAddr_p)
 {
     UINT64 val;
 

--- a/blackchannel/POWERLINK/libs/psicommon/include/libpsicommon/ami.h
+++ b/blackchannel/POWERLINK/libs/psicommon/include/libpsicommon/ami.h
@@ -68,22 +68,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 DLLEXPORT void ami_setUint16Be(void* pAddr_p, UINT16 uint16Val_p);
 DLLEXPORT void ami_setUint16Le(void* pAddr_p, UINT16 uint16Val_p);
 
-DLLEXPORT UINT16 ami_getUint16Be(void* pAddr_p);
-DLLEXPORT UINT16 ami_getUint16Le(void* pAddr_p);
+DLLEXPORT UINT16 ami_getUint16Be(const void* pAddr_p);
+DLLEXPORT UINT16 ami_getUint16Le(const void* pAddr_p);
 
 /* Conversion functions for datatype DWORD */
 DLLEXPORT void ami_setUint32Be(void* pAddr_p, UINT32 uint32Val_p);
 DLLEXPORT void ami_setUint32Le(void* pAddr_p, UINT32 uint32Val_p);
 
-DLLEXPORT UINT32 ami_getUint32Be(void* pAddr_p);
-DLLEXPORT UINT32 ami_getUint32Le(void* pAddr_p);
+DLLEXPORT UINT32 ami_getUint32Be(const void* pAddr_p);
+DLLEXPORT UINT32 ami_getUint32Le(const void* pAddr_p);
 
 /* Conversion functions for datatype QWORD */
 DLLEXPORT void ami_setUint64Be(void* pAddr_p, UINT64 uint64Val_p);
 DLLEXPORT void ami_setUint64Le(void* pAddr_p, UINT64 uint64Val_p);
 
-DLLEXPORT UINT64 ami_getUint64Be(void* pAddr_p);
-DLLEXPORT UINT64 ami_getUint64Le(void* pAddr_p);
+DLLEXPORT UINT64 ami_getUint64Be(const void* pAddr_p);
+DLLEXPORT UINT64 ami_getUint64Le(const void* pAddr_p);
 
 #ifdef __cplusplus
     }

--- a/blackchannel/POWERLINK/libs/psicommon/include/libpsicommon/global.h
+++ b/blackchannel/POWERLINK/libs/psicommon/include/libpsicommon/global.h
@@ -10,6 +10,7 @@ Global header file for the slim interface project
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2016, Kalycito Infotech Private Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,7 +46,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef PSI_BUILD_PCP
   #include <pcptarget/target.h>
-  #include <oplk/ami.h>
+  #include <libpsicommon/ami.h>
 #else
   #include <apptarget/target.h>
   #include <libpsicommon/ami.h>
@@ -75,6 +76,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UNUSED_PARAMETER
   #define UNUSED_PARAMETER(par)   (void)par
 #endif
+
+#define max(a, b)           (((a) > (b)) ? (a) : (b))
 
 /*----------------------------------------------------------------------------*/
 /* Boolean values                                                             */

--- a/blackchannel/POWERLINK/pcp/psi/CMakeLists.txt
+++ b/blackchannel/POWERLINK/pcp/psi/CMakeLists.txt
@@ -3,6 +3,7 @@
 # CMake file of slim interface on pcp for PSI
 #
 # Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2016, Kalycito Infotech Private Ltd
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,6 +35,7 @@ PROJECT( pcppsi C )
 
 ########################################################################
 # Set paths
+SET(DEMO_BOARD_DIR ${CMAKE_SOURCE_DIR}/blackchannel/POWERLINK/fpga/boards/altera/terasic-de2-115)
 SET(OPLK_BASE_DIR ${CMAKE_SOURCE_DIR}/blackchannel/POWERLINK/stacks/openPOWERLINK)
 SET(IP_BASE_DIR ${CMAKE_SOURCE_DIR}/blackchannel/POWERLINK/stacks/ip)
 
@@ -41,7 +43,8 @@ SET(OPLK_STACK_DIR ${OPLK_BASE_DIR}/stack)
 SET(OPLK_APPS_DIR ${OPLK_BASE_DIR}/apps)
 SET(OPLK_HW_DIR ${OPLK_BASE_DIR}/hardware)
 SET(OPLK_OMETHLIB_DIR ${OPLK_HW_DIR}/drivers/openmac)
-
+SET(APP_COMMON_SOURCE_DIR ${OPLK_BASE_DIR}/apps/common/src)
+SET(OBJDICT_DIR ${OPLK_BASE_DIR}/apps/common/objdicts/CiA401_CN)
 ########################################################################
 # Set includes
 INCLUDE(${OPLK_STACK_DIR}/cmake/directories.cmake)
@@ -74,6 +77,7 @@ SET(IP_SRCS
     ${IP_BASE_DIR}/ip_dhcp.c
     ${IP_BASE_DIR}/edrv2veth.c
     ${IP_BASE_DIR}/hton.c
+    ${IP_BASE_DIR}/socketwrapper.c
    )
 
 SET(OPLK_SRCS
@@ -94,6 +98,7 @@ SET(OPLK_SRCS
      ${USER_TIMER_GENERIC_SOURCES}
      ${VETH_USER_NOOS_SOURCES}
      ${COMMON_SOURCES}
+     ${APP_COMMON_SOURCE_DIR}/obdcreate/obdcreate.c
      ${COMMON_CAL_DIRECT_SOURCES}
      ${CIRCBUF_NOOS_SOURCES}
      ${COMMON_NOOS_SOURCES}
@@ -101,6 +106,8 @@ SET(OPLK_SRCS
      ${LIB_KERNEL_SOURCES}
      ${LIB_USER_SOURCES}
      ${LIB_COMMON_SOURCES}
+     ${SDO_SOCKETWRAPPER_SOURCES}
+     ${MEMMAP_NOOSLOCAL_SOURCES}
    )
 
 SET(OMETHLIB_SRCS
@@ -131,20 +138,32 @@ SET(PSI_INCS
     ${psicommonpcp_SOURCE_DIR}/include
     ${DEMO_CONFIG_DIR}/tbuf/include
     ${IP_BASE_DIR}
-   )
+    ${APP_COMMON_DIR}/include/common
+    ${APP_COMMON_SOURCE_DIR}
+    )
 
 SET(OPLK_INCS
     ${STACK_INCLUDE_DIR}
     ${STACK_SOURCE_DIR}
     ${CONTRIB_SOURCE_DIR}
     ${DEMO_CONFIG_DIR}/pcp
-    ${OBJDICT_DIR}/generic
+    #${OBJDICT_DIR}/${OBJDICT}
+    ${CONTRIB_SOURCE_DIR}/socketwrapper
+    ${DEMO_BOARD_DIR}/include
    )
 
 SET(OMETHLIB_INCS
     ${OPLK_OMETHLIB_DIR}/include
     ${OPLK_OMETHLIB_DIR}/src
    )
+
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DCONFIG_DLL_PRES_CHAINING_CN=TRUE -DNMT_MAX_NODE_ID=254 -DCONFIG_INCLUDE_PDO -DCONFIG_INCLUDE_SDO_ASND -DCONFIG_INCLUDE_MASND")
+ADD_DEFINITIONS(-DCONFIG_DLL_PRES_CHAINING_CN)
+ADD_DEFINITIONS(-DNMT_MAX_NODE_ID=254)
+ADD_DEFINITIONS(-DCONFIG_INCLUDE_PDO)
+ADD_DEFINITIONS(-DCONFIG_INCLUDE_SDO_ASND)
+ADD_DEFINITIONS(-DCONFIG_INCLUDE_MASND)
+ADD_DEFINITIONS(-DCONFIG_INCLUDE_SDO_UDP)
 
 IF((CMAKE_SYSTEM_NAME STREQUAL "Generic") AND (CMAKE_SYSTEM_PROCESSOR STREQUAL "nios2"))
     INCLUDE(nios2.cmake)

--- a/blackchannel/POWERLINK/pcp/psi/event.h
+++ b/blackchannel/POWERLINK/pcp/psi/event.h
@@ -60,9 +60,9 @@ typedef tOplkError (*tEventCb)(tOplkApiEventType EventType_p, tOplkApiEventArg* 
 extern "C" {
 #endif
 
-void initEvents (tEventCb pfnEventCb_p);
+void       initEvents (tEventCb pfnEventCb_p);
 tOplkError processEvents(tOplkApiEventType EventType_p,
-        tOplkApiEventArg* pEventArg_p, void* pUserArg_p);
+                         tOplkApiEventArg* pEventArg_p, void* pUserArg_p);
 
 #ifdef __cplusplus
 }

--- a/blackchannel/POWERLINK/pcp/psi/icc.c
+++ b/blackchannel/POWERLINK/pcp/psi/icc.c
@@ -14,6 +14,7 @@ triple buffers.
 * License Agreement
 *
 * Copyright 2014 BERNECKER + RAINER, AUSTRIA, 5142 EGGELSBERG, B&R STRASSE 1
+* Copyright (c) 2016, Kalycito Infotech Private Ltd
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms,
@@ -54,6 +55,7 @@ triple buffers.
 #include <psi/tbuf.h>
 
 #include <oplk/oplk.h>
+#include <debug.h>
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //

--- a/blackchannel/POWERLINK/pcp/psi/include/psi/obdict.h
+++ b/blackchannel/POWERLINK/pcp/psi/include/psi/obdict.h
@@ -60,11 +60,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // function prototypes
 //------------------------------------------------------------------------------
 #if(((PSI_MODULE_INTEGRATION) & (PSI_MODULE_CC)) != 0)
-  extern tOplkError cc_obdAccessCb(tObdCbParam MEM* pParam_p);
+  extern tOplkError cc_obdAccessCb(tObdCbParam* pParam_p);
 #endif
 
 #if(((PSI_MODULE_INTEGRATION) & (PSI_MODULE_SSDO)) != 0)
-  extern tOplkError rssdo_obdAccessCb(tObdCbParam MEM* pParam_p);
+  extern tOplkError rssdo_obdAccessCb(tObdCbParam* pParam_p);
 #endif
 
 #endif /* _INC_psi_obdict_H_ */

--- a/blackchannel/POWERLINK/pcp/psi/logbook.c
+++ b/blackchannel/POWERLINK/pcp/psi/logbook.c
@@ -15,6 +15,7 @@ and forwards the data to the target in the LOGStub.
 * License Agreement
 *
 * Copyright 2014 BERNECKER + RAINER, AUSTRIA, 5142 EGGELSBERG, B&R STRASSE 1
+* Copyright (c) 2016, Kalycito Infotech Private Ltd
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms,
@@ -52,6 +53,7 @@ and forwards the data to the target in the LOGStub.
 #include <psi/logbook.h>
 
 #include <psi/status.h>
+#include <libpsicommon/ami.h>
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
@@ -601,7 +603,9 @@ static tPsiStatus sendToDestTarget(tLogInstance pInstance_p,
             ret = log_consTxTransferFinished(pInstance_p);
             break;
         }
-        case kErrorSdoUdpArpInProgress:
+
+        //Should be included for ipArpquery ipmlementation
+        /*case kErrorSdoUdpArpInProgress:
         {
             // ARP table is still not updated -> Retry to transmit the frame later!
             timeout_startTimer(pInstance_p->pArpTimeoutInst_m);
@@ -609,7 +613,7 @@ static tPsiStatus sendToDestTarget(tLogInstance pInstance_p,
             pInstance_p->consTxState_m = kConsTxStateWaitForNextArpRetry;
 
             break;
-        }
+        }*/
         case  kErrorSdoComHandleBusy:
         {
             // Handle is busy -> try to retransmit later!

--- a/blackchannel/POWERLINK/pcp/psi/nios2.cmake
+++ b/blackchannel/POWERLINK/pcp/psi/nios2.cmake
@@ -3,6 +3,7 @@
 # CMake file of slim interface on pcp (nios2 target) for PSI
 #
 # Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2016, Kalycito Infotech Private Ltd
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -53,9 +54,10 @@ SET(ALT_FLASH_OVERRIDE ${ALT_MISC_DIR}/scripts/nios2-flash-override.txt)
 
 SET(ALT_TARGET_SRCS
     ${PROJECT_SOURCE_DIR}/target/altera/target.c
-    ${ARCH_SOURCE_DIR}/altera_nios2/target-nios2.c
-    ${ARCH_SOURCE_DIR}/altera_nios2/openmac-nios2.c
-    ${ARCH_SOURCE_DIR}/altera_nios2/lock-localnoos.c
+    ${ARCH_SOURCE_DIR}/altera-nios2/target-nios2.c
+    ${ARCH_SOURCE_DIR}/altera-nios2/openmac-nios2.c
+    ${ARCH_SOURCE_DIR}/altera-nios2/lock-localnoos.c
+    ${ARCH_SOURCE_DIR}/altera-nios2/target-mutex.c
     ${OPLK_HW_DIR}/boards/terasic-de2-115/common/drivers/openmac/omethlib_phycfg.c
    )
 
@@ -76,7 +78,7 @@ SET(ALT_PSI_INCS
     ${ALT_PCP_BSP_DIR}
     ${ALT_PCP_BSP_DIR}/HAL/inc
     ${ALT_PCP_BSP_DIR}/drivers/inc
-    ${ARCH_SOURCE_DIR}/altera_nios2
+    ${ARCH_SOURCE_DIR}/altera-nios2
     ${PROJECT_SOURCE_DIR}/target/altera/include
    )
 

--- a/blackchannel/POWERLINK/pcp/psi/occ.c
+++ b/blackchannel/POWERLINK/pcp/psi/occ.c
@@ -14,6 +14,7 @@ triple buffers.
 * License Agreement
 *
 * Copyright 2014 BERNECKER + RAINER, AUSTRIA, 5142 EGGELSBERG, B&R STRASSE 1
+* Copyright (c) 2016, Kalycito Infotech Private Ltd
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms,
@@ -71,7 +72,7 @@ triple buffers.
 // global function prototypes
 //------------------------------------------------------------------------------
 
-extern tOplkError cc_obdAccessCb(tObdCbParam MEM* pParam_p);
+extern tOplkError cc_obdAccessCb(tObdAlConHdl* pParam_p);
 
 //============================================================================//
 //            P R I V A T E   D E F I N I T I O N S                           //
@@ -234,19 +235,18 @@ Exit:
 In case of an access to the local obdict.h of objects which are configuration
 channel objects the local object list needs to be forwarded.
 
-\param[in] pParam_p               Object access parameter
+\param[in] pParam_p       Object access parameter.
 
-\return  tOplkError
-\retval  kErrorOk        On success
+\return    tOplkError
+\retval    kErrorOk       On success.
 
-\ingroup module_main
+\ingroup   module_main
 */
 //------------------------------------------------------------------------------
-tOplkError cc_obdAccessCb(tObdCbParam MEM* pParam_p)
+tOplkError cc_obdAccessCb(tObdAlConHdl* pParam_p)
 {
-    tOplkError oplkret = kErrorOk;
+    tOplkError       oplkret = kErrorOk;
     tConfChanObject  object;
-    UINT16 objSize;
 
     PSI_MEMSET(&object, 0, sizeof(tConfChanObject));
 
@@ -256,52 +256,22 @@ tOplkError cc_obdAccessCb(tObdCbParam MEM* pParam_p)
         goto Exit;
     }
 
-    switch(pParam_p->obdEvent)
+    // Make object size global
+    occInstance_l.objSize_m = pParam_p->totalPendSize;
+
+    object.objIdx_m = pParam_p->index;
+    object.objSubIdx_m = pParam_p->subIndex;
+    object.objSize_m = (UINT16)occInstance_l.objSize_m;
+    PSI_MEMCPY(&object.objPayloadLow_m, pParam_p->pSrcData, occInstance_l.objSize_m);
+
+    if(ccobject_writeObject(&object) == FALSE)
     {
-        case kObdEvInitWrite:
-        {
-            objSize = *(UINT16*)pParam_p->pArg;
-
-            // Check object size (pArg is size of object!)
-            if(objSize > sizeof(UINT64))
-            {
-                oplkret = kErrorObdValueLengthError;
-            }
-            else
-            {
-                // Make object size global
-                occInstance_l.objSize_m = objSize;
-            }
-
-            break;
-        }
-
-        case kObdEvPostWrite:
-        {
-            object.objIdx_m = pParam_p->index;
-            object.objSubIdx_m = pParam_p->subIndex;
-            object.objSize_m = (UINT16)occInstance_l.objSize_m;
-            PSI_MEMCPY(&object.objPayloadLow_m, pParam_p->pArg, occInstance_l.objSize_m);
-
-            if(ccobject_writeObject(&object) == FALSE)
-            {
-                oplkret = kErrorObdAccessViolation;
-            }
-
-            break;
-        }
-        default:
-        {
-            // no action on other events
-            break;
-        }
+        oplkret = kErrorObdAccessViolation;
     }
 
 Exit:
     return oplkret;
-
 }
-
 
 
 //============================================================================//
@@ -395,5 +365,3 @@ Exit:
 }
 
 /// \}
-
-

--- a/blackchannel/POWERLINK/pcp/psi/oplkcfg.h
+++ b/blackchannel/POWERLINK/pcp/psi/oplkcfg.h
@@ -5,13 +5,14 @@
 \brief  Configuration options for openPOWERLINK CN library
 
 This file contains the configuration options for the openPOWERLINK CN libary
-on Xilinx Microblaze.
+on Altera FPGA.
 
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2016, Kalycito Infotech Private Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -56,13 +57,26 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 // These macros define all modules which are included
+#ifndef CONFIG_INCLUDE_PDO
 #define CONFIG_INCLUDE_PDO
+#endif
+
 #define CONFIG_INCLUDE_SDOS
 #define CONFIG_INCLUDE_SDOC
+
+#ifndef CONFIG_INCLUDE_SDO_ASND
 #define CONFIG_INCLUDE_SDO_ASND
-#define CONFIG_INCLUDE_LEDU
+#endif
+
+#define CONFIG_INCLUDE_LEDK
+
+#ifndef CONFIG_INCLUDE_MASND
 #define CONFIG_INCLUDE_MASND
+#endif
+
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_IP
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 #define CONFIG_INCLUDE_SDO_UDP
 
 #define CONFIG_DLLCAL_QUEUE                         DIRECT_QUEUE
@@ -85,10 +99,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_EDRV_AUTO_RESPONSE                   TRUE
 
 // Number of deferred Rx buffers
-#define CONFIG_EDRV_ASND_DEFFERRED_RX_BUFFERS       6
+#define CONFIG_EDRV_ASND_DEFERRED_RX_BUFFERS        6
 
-// Number of deferred Rx buffers for generic ethernet frames
-#define CONFIG_EDRV_VETH_DEFFERRED_RX_BUFFERS       6
+// Number of deferred Rx buffers
+#define CONFIG_EDRV_VETH_DEFERRED_RX_BUFFERS        6
 
 // openMAC supports auto-response delay
 #define CONFIG_EDRV_AUTO_RESPONSE_DELAY             TRUE
@@ -115,7 +129,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_DLL_SOC_SYNC_SHIFT_US                150
 
 // CN supports PRes Chaining
+#ifndef CONFIG_DLL_PRES_CHAINING_CN
 #define CONFIG_DLL_PRES_CHAINING_CN                 TRUE
+#endif
 
 // Disable/Enable late release
 #define CONFIG_DLL_DEFERRED_RXFRAME_RELEASE_SYNC    FALSE
@@ -124,17 +140,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Asynchronous transmit buffer for NMT frames in bytes
 #define CONFIG_DLLCAL_BUFFER_SIZE_TX_NMT            4096
 
-// Asynchronous transmit buffer for generic Asnd frames in bytes
-#define DLLCAL_BUFFER_SIZE_TX_GEN_ASND              8192
-
-// Asynchronous transmit buffer for generic Ethernet frames in bytes
-#define DLLCAL_BUFFER_SIZE_TX_GEN_ETH               8192
-
 // Asynchronous transmit buffer for sync response frames in bytes
 #define CONFIG_DLLCAL_BUFFER_SIZE_TX_SYNC           4096
 
+// Asynchronous transmit buffer for virtual Ethernet frames in bytes
+#define CONFIG_DLLCAL_BUFFER_SIZE_TX_VETH           4096
+
 // Size of kernel to user queue
 #define CONFIG_EVENT_SIZE_CIRCBUF_KERNEL_TO_USER    8192
+
+// Size of kernel internal queue
+#define CONFIG_EVENT_SIZE_CIRCBUF_KERNEL_INTERNAL   1024
 
 // =========================================================================
 // OBD specific defines

--- a/blackchannel/POWERLINK/pcp/psi/psi.c
+++ b/blackchannel/POWERLINK/pcp/psi/psi.c
@@ -15,6 +15,7 @@ the synchronous and asynchronous tasks.
 * License Agreement
 *
 * Copyright 2014 BERNECKER + RAINER, AUSTRIA, 5142 EGGELSBERG, B&R STRASSE 1
+* Copyright (c) 2016, Kalycito Infotech Private Ltd
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms,
@@ -63,6 +64,7 @@ the synchronous and asynchronous tasks.
 #include <psi/logbook.h>
 #include <psi/fifo.h>
 #include <libpsicommon/ccobject.h>
+#include <debug.h>
 
 #include <config/ccobjectlist.h>
 #include <config/triplebuffer.h>

--- a/blackchannel/POWERLINK/pcp/psi/status.c
+++ b/blackchannel/POWERLINK/pcp/psi/status.c
@@ -14,6 +14,7 @@ to the status triple buffer. It also updates the SSDO channel status information
 * License Agreement
 *
 * Copyright 2014 BERNECKER + RAINER, AUSTRIA, 5142 EGGELSBERG, B&R STRASSE 1
+* Copyright (c) 2016, Kalycito Infotech Private Ltd
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms,
@@ -314,8 +315,8 @@ Exit:
 //------------------------------------------------------------------------------
 void status_enableSyncInt(void)
 {
-    /* Enable the interrupt in the EPL status sync module*/
-    synctimer_enableExtSyncIrq(SYNC_INT_CYCLE_NUM, SYNC_INT_PULSE_WIDTH_NS);
+     /* Enable the interrupt in the EPL status sync module*/
+    synctimer_controlExtSyncIrq(TRUE);
 }
 
 //------------------------------------------------------------------------------
@@ -328,7 +329,7 @@ void status_enableSyncInt(void)
 void status_disableSyncInt(void)
 {
     /* Disable the interrupt in the EPL status sync module*/
-    synctimer_disableExtSyncIrq();
+    synctimer_controlExtSyncIrq(FALSE);
 }
 
 //------------------------------------------------------------------------------

--- a/blackchannel/POWERLINK/pcp/psi/tbuf.c
+++ b/blackchannel/POWERLINK/pcp/psi/tbuf.c
@@ -48,6 +48,7 @@ It is instantiated for every triple buffer allocated.
 //------------------------------------------------------------------------------
 #include <psi/internal/tbuf.h>
 #include <psi/tbuf.h>
+#include <libpsicommon/ami.h>
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //

--- a/blackchannel/POWERLINK/pcp/psi/tssdo.c
+++ b/blackchannel/POWERLINK/pcp/psi/tssdo.c
@@ -547,7 +547,7 @@ static tPsiStatus sendToDestTarget(tTssdoInstance pInstance_p,
             ret = tssdo_consTxTransferFinished(pInstance_p);
             break;
         }
-        case kErrorSdoUdpArpInProgress:
+      /*  case kErrorSdoUdpArpInProgress:
         {
             // ARP table is still not updated -> Retry to transmit the frame later!
             timeout_startTimer(pInstance_p->pArpTimeoutInst_m);
@@ -555,7 +555,7 @@ static tPsiStatus sendToDestTarget(tTssdoInstance pInstance_p,
             pInstance_p->consTxState_m = kConsTxStateWaitForNextArpRetry;
 
             break;
-        }
+        }*/
         case  kErrorSdoComHandleBusy:
         {
             // Handle is busy -> try to retransmit later!

--- a/blackchannel/POWERLINK/stacks/ip/socketwrapper-int.h
+++ b/blackchannel/POWERLINK/stacks/ip/socketwrapper-int.h
@@ -1,18 +1,17 @@
 /**
 ********************************************************************************
-\file   edrv2veth.h
+\file   socketwrapper-int.h
 
-\brief  IP stack to Ethernet driver wrapper
+\brief  Internal definitions for socketwrapper
 
-This module converts the driver interface of the IP stack to the interface
-provided from the Virtual Ethernet driver NoOs.
-
+The file contains internal definitions for the socketwrapper.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2013, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2016, Kalycito Infotech Private Ltd
-All rights reserved.
+* License Agreement
+* Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+* Copyright (c) 2016, Kalycito Infotech Pvt. Ltd
+* All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -37,37 +36,36 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------------------------------------------------------------------------------*/
 
-#ifndef _INC_edrv2veth_H_
-#define _INC_edrv2veth_H_
+#ifndef _INC_socketwrapper_int_H_
+#define _INC_socketwrapper_int_H_
 
 //------------------------------------------------------------------------------
 // includes
 //------------------------------------------------------------------------------
-
+#include <oplk/oplk.h>
 #include <ip.h>
 
-//---------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // const defines
-//---------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
-
-//---------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // typedef
-//---------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
-
-//---------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // function prototypes
-//---------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
-tOplkError edrv2veth_init(eth_addr* pEthMac);
-void       edrv2veth_exit(void);
-void       edrv2veth_changeAddress(UINT32 ipAddr_p, UINT32 subNetMask_p, UINT16 mtu_p);
-void       edrv2veth_changeGateway(UINT32 defGateway_p);
-void       edrv2veth_changeGateway(UINT32 defGateway_p);
-void       edrv2veth_setNmtState(tNmtState nmtState_p);
-tOplkError edrv2veth_receiveHandler(UINT8* pFrame_p, UINT32 frameSize_p);
-tOplkError edrv2veth_process(void);
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
+tOplkError      socketwrapper_setIpStackHandle(IP_STACK_H pHandle_p);
 
-#endif /* _INC_edrv2veth_H_ */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _INC_socketwrapper_int_H_ */

--- a/blackchannel/POWERLINK/stacks/ip/socketwrapper.c
+++ b/blackchannel/POWERLINK/stacks/ip/socketwrapper.c
@@ -1,0 +1,385 @@
+/**
+********************************************************************************
+\file   socketwrapper.c
+
+\brief  Socket wrapper module to connect the IP stack with SDO/UDP module.
+
+This module connects the IP stack with the SDO/UDP module.
+
+\ingroup module_ip
+*******************************************************************************/
+
+/*------------------------------------------------------------------------------
+* License Agreement
+*
+* Copyright 2013 BERNECKER + RAINER, AUSTRIA, 5142 EGGELSBERG, B&R STRASSE 1
+* Copyright (c) 2016, Kalycito Infotech Pvt. Ltd.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms,
+* with or without modification,
+* are permitted provided that the following conditions are met:
+*
+*   * Redistributions of source code must retain the above copyright notice,
+*     this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above copyright notice,
+*     this list of conditions and the following disclaimer
+*     in the documentation and/or other materials provided with the
+*     distribution.
+*   * Neither the name of the B&R nor the names of its contributors
+*     may be used to endorse or promote products derived from this software
+*     without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------------------*/
+
+//------------------------------------------------------------------------------
+// includes
+//------------------------------------------------------------------------------
+#include <oplk/oplk.h>
+#include <socketwrapper.h>
+
+#include "ip.h"
+#include "edrv2veth.h"
+#include "socketwrapper-int.h"
+
+//============================================================================//
+//            G L O B A L   D E F I N I T I O N S                             //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+// const defines
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// module global vars
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// global function prototypes
+//------------------------------------------------------------------------------
+
+
+//============================================================================//
+//            P R I V A T E   D E F I N I T I O N S                           //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+// const defines
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// local types
+//------------------------------------------------------------------------------
+
+typedef struct
+{
+    BOOL                    fInitialized;      ///< True if socketwrapper instance shall be created.
+    IP_STACK_H              pIpStackHandle;    ///< Pointer to IP stack handle.
+    tSocketWrapperAddress   socketAddress;     ///< Address of Socket Wrapper.
+    tSocketWrapperReceiveCb socketReceiveCb;   ///< Receive callback function for the socket wrapper.
+} tSocketWrapInstance;
+
+//------------------------------------------------------------------------------
+// local vars
+//------------------------------------------------------------------------------
+static tSocketWrapInstance  instance_l;
+
+//------------------------------------------------------------------------------
+// local function prototypes
+//------------------------------------------------------------------------------
+static void       receiveFromSocket(void* pArg_p, ip_udp_info* pInfo_p);
+static tOplkError updateIpStack(tSocketWrapInstance* pInstance_p);
+
+//============================================================================//
+//            P U B L I C   F U N C T I O N S                                 //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+/**
+\brief  Create socket wrapper instance
+
+The function creates a socket wrapper instance.
+
+\param  pfnReceiveCb_p      Socket receive callback
+
+\return The function returns the created socket wrapper instance.
+\retval NULL    Error, no socket wrapper instance was created!
+
+\ingroup module_socketwrapper
+*/
+//------------------------------------------------------------------------------
+tSocketWrapper socketwrapper_create(tSocketWrapperReceiveCb pfnReceiveCb_p)
+{
+     if (pfnReceiveCb_p == NULL)
+         return NULL;
+
+    memset(&instance_l, 0, sizeof(instance_l));
+
+    instance_l.fInitialized = TRUE;
+    instance_l.socketReceiveCb = pfnReceiveCb_p;
+
+    return (tSocketWrapper)&instance_l;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Bind to socket wrapper instance
+
+The function binds to a certain IP address and port.
+
+\param  pSocketWrapper_p    Socket wrapper instance.
+\param  pSocketAddress_p    Socket address structure.
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_socketwrapper
+*/
+//------------------------------------------------------------------------------
+tOplkError socketwrapper_bind(tSocketWrapper pSocketWrapper_p,
+                              tSocketWrapperAddress* pSocketAddress_p)
+{
+    tOplkError              ret = kErrorOk;
+    tSocketWrapInstance*    pInstance = (tSocketWrapInstance*)pSocketWrapper_p;
+
+    UNUSED_PARAMETER(pSocketWrapper_p);
+
+    if (pInstance == NULL)
+        return kErrorSdoUdpInvalidHdl;
+
+    if (!pInstance->fInitialized)
+        return kErrorSdoUdpSocketError;
+
+    pInstance->socketAddress = *pSocketAddress_p;
+
+    if (pInstance->pIpStackHandle != NULL)
+    {
+        ret = updateIpStack(pInstance);
+        if (ret != kErrorOk)
+            return ret;
+    }
+
+    return ret;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Close socket wrapper instance
+
+The function closes the given socket wrapper instance.
+
+\param  pSocketWrapper_p    Socket wrapper instance.
+\param  pSocketAddress_p    Socket address structure.
+
+\ingroup module_socketwrapper
+*/
+//------------------------------------------------------------------------------
+void socketwrapper_close(tSocketWrapper pSocketWrapper_p)
+{
+    tSocketWrapInstance*    pInstance = (tSocketWrapInstance*)pSocketWrapper_p;
+
+    if (pInstance == NULL)
+        return;
+
+    pInstance->fInitialized = FALSE;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Send to socket wrapper instance
+
+The function sends the given data to the remote address.
+
+\param  pSocketWrapper_p    Socket wrapper instance.
+\param  pRemote_p           Pointer to remote socketwrapper address.
+\param  pData_p             Pointer to payload data.
+\param  dataSize_p          Size of payload data.
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_socketwrapper
+*/
+//------------------------------------------------------------------------------
+tOplkError socketwrapper_send(tSocketWrapper pSocketWrapper_p,
+                              tSocketWrapperAddress* pRemote_p,
+                              UINT8* pData_p, UINT dataSize_p)
+{
+    tSocketWrapInstance*    pInstance = (tSocketWrapInstance*)pSocketWrapper_p;
+    INT                     error;
+    ip_udp_info             udpInfo;
+
+    if (pInstance == NULL)
+        return kErrorSdoUdpInvalidHdl;
+
+    if (!pInstance->fInitialized)
+        return kErrorSdoUdpSocketError;
+
+    udpInfo.pData = pData_p;
+    udpInfo.len = dataSize_p;
+    udpInfo.localPort = instance_l.socketAddress.port;
+    udpInfo.localHost.S_un.S_addr = instance_l.socketAddress.ipAddress;
+    udpInfo.remotePort = htons(pRemote_p->port);
+    udpInfo.remoteHost.S_un.S_addr = pRemote_p->ipAddress;
+
+    error = ipUdpSend(pInstance->pIpStackHandle, &udpInfo);
+    if (error != (INT)dataSize_p)
+        return kErrorSdoUdpSendError;
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Critical section
+
+The function handles critical sections for the SDO/UDP module.
+
+\param  fEnable_p           Specifies if a critical section shall be entered (TRUE)
+                            or left (FALSE).
+
+\ingroup module_socketwrapper
+*/
+//------------------------------------------------------------------------------
+void socketwrapper_criticalSection(BOOL fEnable_p)
+{
+    (void)fEnable_p;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Set IP stack handle
+
+The function sets the IP stack handle to the socket wrapper instance.
+
+\param  pHandle_p           The IP stack handle
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_socketwrapper
+*/
+//------------------------------------------------------------------------------
+tOplkError socketwrapper_setIpStackHandle(IP_STACK_H pHandle_p)
+{
+    tSocketWrapInstance*    pInstance = (tSocketWrapInstance*)&instance_l;
+
+    if (pInstance == NULL)
+        return kErrorSdoUdpInvalidHdl;
+
+    if (!pInstance->fInitialized)
+        return kErrorApiNotInitialized;
+
+    pInstance->pIpStackHandle = (IP_STACK_H)pHandle_p;
+
+    return updateIpStack(pInstance);
+}
+
+//============================================================================//
+//            P R I V A T E   F U N C T I O N S                               //
+//============================================================================//
+/// \name Private Functions
+/// \{
+
+//------------------------------------------------------------------------------
+/**
+\brief  Socket receive callback
+
+The function is called by the IP stack socket if a frame is received.
+
+\param  pArg_p              Argument pointer holding the socket wrapper instance.
+\param  pInfo_p             Pointer to UDP frame info.
+
+*/
+//------------------------------------------------------------------------------
+static void receiveFromSocket(void* pArg_p, ip_udp_info* pInfo_p)
+{
+    tSocketWrapInstance*    pInstance = (tSocketWrapInstance*)pArg_p;
+    tSocketWrapperAddress   remote;
+
+    if (pInstance == NULL)
+        return;
+
+    if ((!pInstance->fInitialized) || (pInstance->pIpStackHandle == NULL))
+        return;
+
+    remote.ipAddress = pInfo_p->remoteHost.S_un.S_addr;
+    remote.port = htons(pInfo_p->remotePort);
+
+    pInstance->socketReceiveCb((UINT8*)pInfo_p->pData, pInfo_p->len, &remote);
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Update IP stack
+
+The function updates the IP stack with the socket wrapper settings (IP address).
+
+\param  pInstance_p         Pointer to socket wrapper instance
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError updateIpStack(tSocketWrapInstance* pInstance_p)
+{
+    UINT32  ipAddr = htonl(pInstance_p->socketAddress.ipAddress);
+    INT     error;
+
+    ipChangeAddress(pInstance_p->pIpStackHandle, (struct in_addr*)&ipAddr);
+
+    error = ipUdpListen(pInstance_p->pIpStackHandle, pInstance_p->socketAddress.port,
+                        receiveFromSocket, pInstance_p);
+    if (error < 0)
+        return kErrorSdoUdpInvalidHdl;
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  The function handles the Arp Query
+
+The function is called when a new SDO connection is initialized to handle the Arprequests
+of the remote nodes.
+
+\param  pSocketWrapper_p   Socket wrapper instance
+
+\param  remoteIpAddress_p  Ip Address
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+
+/*tOplkError socketwrapper_arpQuery(tSocketWrapper pSocketWrapper_p,
+                                       UINT32 remoteIpAddress_p)
+{
+    eth_addr       macAddr;
+    eth_addr       macAddrZero;
+    tOplkError     ret = kErrorOk;
+
+    UNUSED_PARAMETER(pSocketWrapper_p);
+    memset(&macAddrZero, 0, sizeof(eth_addr));
+    memset(&macAddr, 0, sizeof(eth_addr));
+
+    // if target node MAC is unknown return with error
+    ipArpQuery(remoteIpAddress_p, &macAddr);
+    if(!memcmp(&macAddr , &macAddrZero , sizeof(eth_addr)))
+    {
+         printf(" Inside socketwrapper_arpQuery\n");
+        // send ARP request when MAC is unknown!
+        ipArpRequest(remoteIpAddress_p, &macAddr);
+        ret = kErrorSdoUdpArpInProgress;
+    }
+       return ret;
+
+}*/
+
+/// \}


### PR DESCRIPTION
This pull requests contains the components for openSAFETY demo integration rebased on openPOWERLINK 2.5.0.

Following components are added
1) SocketWrapper module for IP Stack 
2) Upgrade demo-sn-gpio HW design to use openMAC 1.0.2

The changes are tested with openPOWERLINK 2.5.0 rc1.

Known Issues:
1. The Safety operation could not be verified because of a board issue in the safety application processor board at Kalycito.
